### PR TITLE
remove mask preventing id from being setup properly in new_with_id

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -41,7 +41,6 @@ where
     }
 
     pub fn new_with_id(id: uuid::Uuid, data: E, topic: Option<Topic>) -> Self {
-        let id = uuid::Uuid::new_v4();
         let timestamp = chrono::Utc::now().timestamp();
 
         Self {


### PR DESCRIPTION
Id was being re-generated during new_with_id and masking the original input value. 